### PR TITLE
Issue 56 utc offset

### DIFF
--- a/basin3d/synthesis/serializers.py
+++ b/basin3d/synthesis/serializers.py
@@ -459,7 +459,7 @@ class MeasurementTimeseriesTVPObservationSerializer(ObservationSerializerMixin, 
     result_points = serializers.SerializerMethodField()
     unit_of_measurement = serializers.CharField()
 
-    FIELDS_OPTIONAL = {'aggregation_duration', 'time_reference_position', 'utc_offset', 'statistic'}
+    FIELDS_OPTIONAL = {'aggregation_duration', 'time_reference_position', 'statistic'}
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
Makes utc_offset in MeasurementTimeseriesTVPObservationSerializer required.

Closes #56 

Tests pass.
Tested locally via end-to-end.