### PR TITLE
Make utc offset in measTVPobs required so that 0 is not dropped

### DIFF
--- a/django_basin3d/synthesis/serializers.py
+++ b/django_basin3d/synthesis/serializers.py
@@ -412,7 +412,7 @@ class MeasurementTimeseriesTVPObservationSerializer(ObservationSerializerMixin, 
     result_points = serializers.SerializerMethodField()
     unit_of_measurement = serializers.CharField(read_only=True)
 
-    FIELDS_OPTIONAL = {'aggregation_duration', 'time_reference_position', 'utc_offset', 'statistic'}
+    FIELDS_OPTIONAL = {'aggregation_duration', 'time_reference_position', 'statistic'}
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
Closes #56

All tests pass.
Tested locally end to end.